### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
### Description

- chore: add .gitattributes to enforce LF line endings
