### PR TITLE
build(deps)!: drop Laravel 9 support, add Laravel 10 CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
 * text=auto eol=lf
+
+# Exclude dev-only files from the Composer dist tarball
+/.github        export-ignore
+/.idea          export-ignore
+/tests          export-ignore
+/.gitattributes export-ignore
+/.gitignore     export-ignore
+/phpunit.xml    export-ignore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,10 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Explicit combinations: Laravel 9 supports PHP 8.0–8.2, Laravel 10 supports PHP 8.1–8.3.
+        # Laravel 10 supports PHP 8.1–8.3.
         include:
-          - { php: '8.1', laravel: '9.*', testbench: '7.*' }
-          - { php: '8.2', laravel: '9.*', testbench: '7.*' }
           - { php: '8.1', laravel: '10.*', testbench: '8.*' }
           - { php: '8.2', laravel: '10.*', testbench: '8.*' }
           - { php: '8.3', laravel: '10.*', testbench: '8.*' }
@@ -36,8 +34,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Laravel 9 and 10 are EOL and carry unpatched advisories; allow
-          # installing them so we can still test compatibility against them.
+          # Laravel 10 is EOL and carries unpatched advisories; allow installing
+          # it so we can still test compatibility against it.
           composer config --no-plugins policy.advisories.block false
           composer require \
             "laravel/framework:${{ matrix.laravel }}" \

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Laravel 9 and 10 are EOL and carry unpatched advisories; allow
+          # installing them so we can still test compatibility against them.
+          composer config --no-plugins policy.advisories.block false
           composer require \
             "laravel/framework:${{ matrix.laravel }}" \
             "orchestra/testbench:${{ matrix.testbench }}" \

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,50 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+        laravel: ['9.*', '10.*']
+        include:
+          - laravel: '9.*'
+            testbench: '7.*'
+          - laravel: '10.*'
+            testbench: '8.*'
+        exclude:
+          # Laravel 9 supports PHP 8.0–8.2 only.
+          - laravel: '9.*'
+            php: '8.3'
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, fileinfo, pdo, sqlite3, pdo_sqlite
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require \
+            "laravel/framework:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}" \
+            --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,17 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
-        laravel: ['9.*', '10.*']
+        # Explicit combinations: Laravel 9 supports PHP 8.0–8.2, Laravel 10 supports PHP 8.1–8.3.
         include:
-          - laravel: '9.*'
-            testbench: '7.*'
-          - laravel: '10.*'
-            testbench: '8.*'
-        exclude:
-          # Laravel 9 supports PHP 8.0–8.2 only.
-          - laravel: '9.*'
-            php: '8.3'
+          - { php: '8.1', laravel: '9.*', testbench: '7.*' }
+          - { php: '8.2', laravel: '9.*', testbench: '7.*' }
+          - { php: '8.1', laravel: '10.*', testbench: '8.*' }
+          - { php: '8.2', laravel: '10.*', testbench: '8.*' }
+          - { php: '8.3', laravel: '10.*', testbench: '8.*' }
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 A Laravel package for making payments through the EuPago API.
 
+[![Tests](https://img.shields.io/github/actions/workflow/status/CodeTechAgency/laravel-eupago/run-tests.yml?branch=master&style=flat-square&label=tests)](https://github.com/CodeTechAgency/laravel-eupago/actions/workflows/run-tests.yml)
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/laravel-eupago?style=flat-square)](https://github.com/CodeTechAgency/laravel-eupago/releases)
 [![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-eupago?style=flat-square)](https://github.com/CodeTechAgency/laravel-eupago/blob/master/LICENSE)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrading
 
+## From v2.x to v3.0.0
+
+This release drops support for Laravel 9.x (and PHP 8.0). Make sure your application runs Laravel 10.x or higher on PHP 8.1+. No changes to your application code are required.
+
 ## From v1.x to v2.0.0
 
 This release drops support for PHP 7.x and Laravel 8.x. No changes to your application code are required.

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^8.0.2",
-    "laravel/framework": "^9.0|^10.0",
+    "php": "^8.1",
+    "laravel/framework": "^10.0",
     "guzzlehttp/guzzle": "^7.0"
   },
   "autoload": {
@@ -44,7 +44,7 @@
   },
   "require-dev": {
     "pestphp/pest": "^2.36",
-    "orchestra/testbench": "^7.0|^8.0"
+    "orchestra/testbench": "^8.0"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
   },
   "require-dev": {
     "pestphp/pest": "^2.36",
-    "pestphp/pest-plugin-laravel": "^2.4",
     "orchestra/testbench": "^7.0|^8.0"
   },
   "config": {


### PR DESCRIPTION
### Description

- ci(actions): add test matrix for Laravel 9 and 10
- docs(readme): add tests status badge
- chore(dist): export-ignore dev files from the package archive

### Fixes

Closes #28 




