### PR TITLE
refactor(http): replace Guzzle with Laravel HTTP client in MB/MBWay

### DIFF
--- a/src/MB/MB.php
+++ b/src/MB/MB.php
@@ -127,6 +127,7 @@ class MB extends EuPago
      *
      * @return array
      * @throws \Illuminate\Http\Client\ConnectionException
+     * @throws \Illuminate\Http\Client\RequestException
      */
     public function create(): array
     {

--- a/src/MB/MB.php
+++ b/src/MB/MB.php
@@ -4,7 +4,7 @@ namespace CodeTech\EuPago\MB;
 
 use Carbon\Carbon;
 use CodeTech\EuPago\EuPago;
-use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Http;
 
 class MB extends EuPago
 {
@@ -123,22 +123,16 @@ class MB extends EuPago
     }
 
     /**
-     * Generates a new MBWay reference.
+     * Generates a new MB reference.
      *
      * @return array
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function create(): array
     {
-        $client = new Client(['base_uri' => $this->getBaseUri()]);
+        $response = Http::asForm()->post($this->getBaseUri() . self::URI, $this->getParams())->throw();
 
-        try {
-            $response = $client->post(self::URI, $this->getParams());
-        } catch (\Exception $e) {
-            throw $e;
-        }
-
-        $referenceData = json_decode($response->getBody()->getContents(), true);
+        $referenceData = $response->json();
 
         if (!$referenceData['sucesso']) {
             $this->addError($referenceData['estado'], $referenceData['resposta']);
@@ -177,16 +171,14 @@ class MB extends EuPago
     protected function getParams(): array
     {
         return [
-            'form_params' => [
-                'chave' => config('eupago.api_key'),
-                'valor' => $this->value,
-                'id' => $this->id,
-                'data_inicio' => $this->startDate,
-                'data_fim' => $this->endDate,
-                'valor_minimo' => $this->minValue,
-                'valor_maximo' => $this->maxValue,
-                'per_dup' => $this->allowDuplication,
-            ]
+            'chave' => config('eupago.api_key'),
+            'valor' => $this->value,
+            'id' => $this->id,
+            'data_inicio' => $this->startDate,
+            'data_fim' => $this->endDate,
+            'valor_minimo' => $this->minValue,
+            'valor_maximo' => $this->maxValue,
+            'per_dup' => $this->allowDuplication,
         ];
     }
 }

--- a/src/MBWay/MBWay.php
+++ b/src/MBWay/MBWay.php
@@ -97,10 +97,11 @@ class MBWay extends EuPago
     /**
      * Generates a new MBWay reference.
      *
-     * @return mixed
+     * @return array
      * @throws \Illuminate\Http\Client\ConnectionException
+     * @throws \Illuminate\Http\Client\RequestException
      */
-    public function create()
+    public function create(): array
     {
         $response = Http::asForm()->post($this->getBaseUri() . self::URI, $this->getParams())->throw();
 

--- a/src/MBWay/MBWay.php
+++ b/src/MBWay/MBWay.php
@@ -3,7 +3,7 @@
 namespace CodeTech\EuPago\MBWay;
 
 use CodeTech\EuPago\EuPago;
-use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Http;
 
 class MBWay extends EuPago
 {
@@ -98,14 +98,13 @@ class MBWay extends EuPago
      * Generates a new MBWay reference.
      *
      * @return mixed
+     * @throws \Illuminate\Http\Client\ConnectionException
      */
     public function create()
     {
-        $client = new Client(['base_uri' => $this->getBaseUri()]);
+        $response = Http::asForm()->post($this->getBaseUri() . self::URI, $this->getParams())->throw();
 
-        $response = $client->post(self::URI, $this->getParams());
-
-        $referenceData = json_decode($response->getBody()->getContents(), true);
+        $referenceData = $response->json();
 
         if (!$referenceData['sucesso']) {
             $this->addError($referenceData['estado'], $referenceData['resposta']);
@@ -140,13 +139,11 @@ class MBWay extends EuPago
     protected function getParams(): array
     {
         return [
-            'form_params' => [
-                'chave' => config('eupago.api_key'),
-                'valor' => $this->value,
-                'id' => $this->id,
-                'alias' => $this->alias,
-                'descricao' => $this->description,
-            ]
+            'chave' => config('eupago.api_key'),
+            'valor' => $this->value,
+            'id' => $this->id,
+            'alias' => $this->alias,
+            'descricao' => $this->description,
         ];
     }
 }

--- a/tests/Feature/MbCreationTest.php
+++ b/tests/Feature/MbCreationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Carbon\Carbon;
+use CodeTech\EuPago\MB\MB;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+function makeMb(): MB
+{
+    return new MB(10.50, '1', Carbon::parse('2026-06-01'), Carbon::parse('2026-06-30'), 0, 100);
+}
+
+it('creates an MB reference and maps the response keys', function () {
+    Http::fake(['*' => Http::response([
+        'sucesso' => true,
+        'estado' => 0,
+        'resposta' => 'OK',
+        'entidade' => '12345',
+        'referencia' => '999888777',
+        'valor' => 10.50,
+        'valor_minimo' => 0,
+        'valor_maximo' => 100,
+        'data_inicio' => '2026-06-01',
+        'data_fim' => '2026-06-30',
+    ])]);
+
+    $result = makeMb()->create();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['reference'])->toBe('999888777')
+        ->and($result['entity'])->toBe('12345');
+});
+
+it('sends the MB creation request with the configured credentials', function () {
+    Http::fake(['*' => Http::response(['sucesso' => true])]);
+
+    makeMb()->create();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'multibanco/create')
+        && $request['chave'] === config('eupago.api_key')
+        && $request['valor'] == 10.50);
+});
+
+it('throws when the MB API returns a server error', function () {
+    Http::fake(['*' => Http::response('Server Error', 500)]);
+
+    expect(fn () => makeMb()->create())->toThrow(RequestException::class);
+});
+
+it('records an error when the MB API reports failure', function () {
+    Http::fake(['*' => Http::response([
+        'sucesso' => false,
+        'estado' => 11,
+        'resposta' => 'Chave de API inv&aacute;lida',
+    ])]);
+
+    $mb = makeMb();
+    $mb->create();
+
+    expect($mb->hasErrors())->toBeTrue()
+        ->and($mb->getErrors())->toHaveKey(11);
+});

--- a/tests/Feature/MbwayCreationTest.php
+++ b/tests/Feature/MbwayCreationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use CodeTech\EuPago\MBWay\MBWay;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+it('creates an MBWay reference and maps the response keys', function () {
+    Http::fake(['*' => Http::response([
+        'sucesso' => true,
+        'estado' => 0,
+        'resposta' => 'OK',
+        'referencia' => '900111222',
+        'valor' => 15.0,
+        'alias' => '912345678',
+    ])]);
+
+    $result = (new MBWay(15.0, 1, '912345678'))->create();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['reference'])->toBe('900111222')
+        ->and($result['alias'])->toBe('912345678');
+});
+
+it('sends the MBWay creation request with the configured credentials', function () {
+    Http::fake(['*' => Http::response(['sucesso' => true])]);
+
+    (new MBWay(15.0, 1, '912345678'))->create();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'mbway/create')
+        && $request['chave'] === config('eupago.api_key')
+        && $request['alias'] === '912345678');
+});
+
+it('throws when the MBWay API returns a server error', function () {
+    Http::fake(['*' => Http::response('Server Error', 500)]);
+
+    expect(fn () => (new MBWay(15.0, 1, '912345678'))->create())->toThrow(RequestException::class);
+});
+
+it('records an error when the MBWay API reports failure', function () {
+    Http::fake(['*' => Http::response([
+        'sucesso' => false,
+        'estado' => 12,
+        'resposta' => 'Erro',
+    ])]);
+
+    $mbway = new MBWay(15.0, 1, '912345678');
+    $mbway->create();
+
+    expect($mbway->hasErrors())->toBeTrue()
+        ->and($mbway->getErrors())->toHaveKey(12);
+});


### PR DESCRIPTION
### Description

- refactor(http): replace Guzzle with Laravel HTTP client in MB/MBWay
- test(http): cover MB/MBWay create, error, and server-failure flows

### Fixes

Closes #32 




