### PR TITLE
fix(mbway): use explicit nullable type for $description (PHP 8.4)

### DIFF
--- a/src/MBWay/MBWay.php
+++ b/src/MBWay/MBWay.php
@@ -51,8 +51,8 @@ class MBWay extends EuPago
      * MBWay constructor.
      *
      * @param float $value
-     * @param string $id
-     * @param int $alias
+     * @param int $id
+     * @param string $alias
      * @param string|null $description
      */
     public function __construct(float $value, int $id, string $alias, ?string $description = null)

--- a/src/MBWay/MBWay.php
+++ b/src/MBWay/MBWay.php
@@ -55,7 +55,7 @@ class MBWay extends EuPago
      * @param int $alias
      * @param string|null $description
      */
-    public function __construct(float $value, int $id, string $alias, string $description = null)
+    public function __construct(float $value, int $id, string $alias, ?string $description = null)
     {
         $this->value       = $value;
         $this->id          = $id;


### PR DESCRIPTION
### Description

- fix(mbway): use explicit nullable type for $description (PHP 8.4)

### Fixes

Closes #33 




