### PR TITLE
feat(payshop): add PayShop reference support

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ GET
 | canal         | string    |
 | referencia    | string    |
 | transacao     | string    |
-| identificador | integer   |
+| identificador | string    |
 | mp            | string    |
 | chave_api     | string    |
 | data          | date time |

--- a/README.md
+++ b/README.md
@@ -203,6 +203,93 @@ GET
 
 
 
+### PayShop References
+
+#### Usage
+
+For creating a PayShop reference, take the following example:
+```
+use CodeTech\EuPago\PayShop\PayShop;
+
+$order = Order::find(1);
+
+$payShop = new PayShop(
+    $order->value,
+    $order->id
+);
+
+try {
+    // Make the request to EUPago's API
+    $payShopReferenceData = $payShop->create();
+
+    if ($payShop->hasErrors()) {
+        // handle errors
+    }
+
+    $order->payShopReferences()->create($payShopReferenceData);
+} catch (\Exception $e) {
+    // handle exception
+}
+```
+
+`$payShopReferenceData` will contain all the information about the payment:
+```
+[
+    'success' => true,
+    'state' => 0,
+    'response' => "OK",
+    'reference' => 1800000132722,
+    'value' => "10.00000",
+]
+```
+
+Use the trait on the models for which you want to generate PayShop references:
+
+```
+
+use CodeTech\EuPago\Traits\PayShopable;
+
+class Order extends Model
+{
+    use PayShopable;
+
+```
+
+Retrieve the PayShop references:
+
+```
+$order = Order::find(1);
+
+$payShopReferences = $order->payShopReferences;
+```
+
+#### Callback
+
+The package already handles the callback, updating the payment reference state and triggering a `PayShopReferencePaid` event.
+
+```
+GET
+
+/eupago/payshop/callback
+```
+
+#### Params
+
+| Name          | Type      |
+|---------------|:---------:|
+| valor         | float     |
+| canal         | string    |
+| referencia    | string    |
+| transacao     | string    |
+| identificador | integer   |
+| mp            | string    |
+| chave_api     | string    |
+| data          | date time |
+| entidade      | string    |
+| comissao      | float     |
+| local         | string    |
+
+
 ---
 
 

--- a/database/migrations/2026_06_26_000000_create_payshop_references_table.php
+++ b/database/migrations/2026_06_26_000000_create_payshop_references_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('payshop_references', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('reference')->unique();
-            $table->float('value', 10, 2)->default(0);
+            $table->decimal('value', 10, 2)->default(0);
             $table->integer('state')->default(0);
             $table->morphs('payshopable');
             $table->timestamps();

--- a/database/migrations/2026_06_26_000000_create_payshop_references_table.php
+++ b/database/migrations/2026_06_26_000000_create_payshop_references_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('payshop_references', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('reference')->unique();
+            $table->float('value', 10, 2)->default(0);
+            $table->integer('state')->default(0);
+            $table->morphs('payshopable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('payshop_references');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use CodeTech\EuPago\Http\Controllers\MBController;
 use CodeTech\EuPago\Http\Controllers\MBWayController;
+use CodeTech\EuPago\Http\Controllers\PayShopController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -18,4 +19,9 @@ Route::prefix('mb')->name('mb.')->group(function () {
 // MB Way
 Route::prefix('mbway')->name('mbway.')->group(function () {
     Route::get('callback', [MBWayController::class, 'callback'])->name('callback');
+});
+
+// PayShop
+Route::prefix('payshop')->name('payshop.')->group(function () {
+    Route::get('callback', [PayShopController::class, 'callback'])->name('callback');
 });

--- a/src/Events/PayShopReferencePaid.php
+++ b/src/Events/PayShopReferencePaid.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace CodeTech\EuPago\Events;
+
+use CodeTech\EuPago\Models\PayShopReference;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PayShopReferencePaid
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * The PayShop reference object.
+     *
+     * @var PayShopReference
+     */
+    public $reference;
+
+    /**
+     * PayShopReferencePaid constructor.
+     *
+     * @param PayShopReference $reference
+     */
+    public function __construct(PayShopReference $reference)
+    {
+        $this->reference = $reference;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/src/Http/Controllers/PayShopController.php
+++ b/src/Http/Controllers/PayShopController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CodeTech\EuPago\Http\Controllers;
+
+use CodeTech\EuPago\Events\PayShopReferencePaid;
+use CodeTech\EuPago\Http\Requests\PayShopCallbackRequest;
+use CodeTech\EuPago\Models\PayShopReference;
+
+class PayShopController extends Controller
+{
+    /**
+     * This endpoint is called when a PayShop reference is paid.
+     *
+     * @param PayShopCallbackRequest $request
+     * @return \Illuminate\Http\JsonResponse|object
+     */
+    public function callback(PayShopCallbackRequest $request)
+    {
+        $validatedData = $request->validated();
+
+        $reference = PayShopReference::where('reference', $validatedData['referencia'])
+            ->where('value', $validatedData['valor'])
+            ->where('state', 0)
+            ->first();
+
+        if (!$reference) {
+            return response()->json(['response' => 'No pending reference found'])->setStatusCode(404);
+        }
+
+        $reference->update(['state' => 1]);
+
+        // trigger event
+        event(new PayShopReferencePaid($reference));
+
+        return response()->json(['response' => 'Success'])->setStatusCode(200);
+    }
+}

--- a/src/Http/Requests/PayShopCallbackRequest.php
+++ b/src/Http/Requests/PayShopCallbackRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CodeTech\EuPago\Http\Requests;
+
+use Illuminate\Validation\Rule;
+
+class PayShopCallbackRequest extends CallbackRequest
+{
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $parentRules = parent::rules();
+
+        $parentRules['referencia'][] = Rule::exists('payshop_references', 'reference');
+
+        return $parentRules;
+    }
+}

--- a/src/Models/PayShopReference.php
+++ b/src/Models/PayShopReference.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace CodeTech\EuPago\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PayShopReference extends Model
+{
+    /**
+     * @inheritdoc
+     */
+    protected $table = 'payshop_references';
+
+    /**
+     * @inheritdoc
+     */
+    protected $fillable = [
+        'reference',
+        'value',
+        'state',
+    ];
+
+    protected $casts = [
+        'value' => 'float',
+        'state' => 'integer',
+    ];
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Scopes
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Scopes a query to only include paid references.
+     *
+     * @param $query
+     * @return mixed
+     */
+    public function scopePaid($query)
+    {
+        return $query->where('state', 1);
+    }
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Relationships
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Get the owning payshopable model.
+     */
+    public function payshopable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/src/PayShop/PayShop.php
+++ b/src/PayShop/PayShop.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace CodeTech\EuPago\PayShop;
+
+use CodeTech\EuPago\EuPago;
+use Illuminate\Support\Facades\Http;
+
+class PayShop extends EuPago
+{
+    /**
+     * The unique resource identifier.
+     */
+    const URI = '/clientes/rest_api/payshop/create';
+
+    /**
+     * The payment value.
+     *
+     * @var float
+     */
+    protected $value;
+
+    /**
+     * External identifier. Ex: the order id.
+     *
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * The errors stored during the operations.
+     *
+     * @var array
+     */
+    protected $errors = [];
+
+    /**
+     * PayShop constructor.
+     *
+     * @param float $value
+     * @param string $id
+     */
+    public function __construct(float $value, string $id)
+    {
+        $this->value = $value;
+        $this->id    = $id;
+    }
+
+    /**
+     * Returns the errors.
+     *
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Adds an error to the bag.
+     *
+     * @param $code
+     * @param $message
+     */
+    protected function addError($code, $message)
+    {
+        $this->errors[$code] = html_entity_decode($message);
+    }
+
+    /**
+     * Determines whether errors are logged.
+     *
+     * @return bool
+     */
+    public function hasErrors()
+    {
+        return count($this->errors) > 0;
+    }
+
+    /**
+     * Generates a new PayShop reference.
+     *
+     * @return array
+     * @throws \Illuminate\Http\Client\ConnectionException
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function create(): array
+    {
+        $response = Http::asForm()->post($this->getBaseUri() . self::URI, $this->getParams())->throw();
+
+        $referenceData = $response->json();
+
+        if (!$referenceData['sucesso']) {
+            $this->addError($referenceData['estado'], $referenceData['resposta']);
+        }
+
+        return $this->mappedReferenceKeys($referenceData);
+    }
+
+    /**
+     * Maps the reference data keys.
+     *
+     * @param array $referenceData
+     * @return array
+     */
+    protected function mappedReferenceKeys(array $referenceData): array
+    {
+        return [
+            'success' => $referenceData['sucesso'] ?? null,
+            'state' => $referenceData['estado'] ?? null,
+            'response' => $referenceData['resposta'] ?? null,
+            'reference' => $referenceData['referencia'] ?? null,
+            'value' => $referenceData['valor'] ?? null,
+        ];
+    }
+
+    /**
+     * Returns the required params for making a request.
+     *
+     * @return array
+     */
+    protected function getParams(): array
+    {
+        return [
+            'chave' => config('eupago.api_key'),
+            'valor' => $this->value,
+            'id' => $this->id,
+        ];
+    }
+}

--- a/src/Traits/PayShopable.php
+++ b/src/Traits/PayShopable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CodeTech\EuPago\Traits;
+
+use CodeTech\EuPago\Models\PayShopReference;
+
+trait PayShopable
+{
+    /**
+     * Get all of the model's PayShop references.
+     */
+    public function payShopReferences()
+    {
+        return $this->morphMany(PayShopReference::class, 'payshopable');
+    }
+}

--- a/tests/Feature/PackageBootTest.php
+++ b/tests/Feature/PackageBootTest.php
@@ -7,5 +7,6 @@ it('merges the eupago config when the package boots', function () {
 
 it('registers the eupago callback routes', function () {
     expect(app('router')->has('eupago.mb.callback'))->toBeTrue()
-        ->and(app('router')->has('eupago.mbway.callback'))->toBeTrue();
+        ->and(app('router')->has('eupago.mbway.callback'))->toBeTrue()
+        ->and(app('router')->has('eupago.payshop.callback'))->toBeTrue();
 });

--- a/tests/Feature/PayShopCallbackTest.php
+++ b/tests/Feature/PayShopCallbackTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use CodeTech\EuPago\Events\PayShopReferencePaid;
+use Illuminate\Support\Facades\Event;
+
+it('marks a pending PayShop reference as paid and dispatches the event', function () {
+    Event::fake([PayShopReferencePaid::class]);
+    $reference = createPendingPayShopReference();
+
+    $response = $this->getJson(route('eupago.payshop.callback', validPayShopCallbackPayload()));
+
+    $response->assertOk()->assertJson(['response' => 'Success']);
+    expect((int) $reference->fresh()->state)->toBe(1);
+    Event::assertDispatched(
+        PayShopReferencePaid::class,
+        fn (PayShopReferencePaid $event) => $event->reference->is($reference)
+    );
+});
+
+it('returns 404 when the reference exists but the value does not match', function () {
+    Event::fake([PayShopReferencePaid::class]);
+    createPendingPayShopReference();
+
+    $response = $this->getJson(route('eupago.payshop.callback', validPayShopCallbackPayload([
+        'valor' => '99.99',
+    ])));
+
+    $response->assertNotFound()->assertJson(['response' => 'No pending reference found']);
+    Event::assertNotDispatched(PayShopReferencePaid::class);
+});
+
+it('returns 404 when the matching PayShop reference is already paid', function () {
+    createPendingPayShopReference(['state' => 1]);
+
+    $response = $this->getJson(route('eupago.payshop.callback', validPayShopCallbackPayload()));
+
+    $response->assertNotFound();
+});
+
+it('rejects a PayShop callback for a reference that does not exist', function () {
+    $response = $this->getJson(route('eupago.payshop.callback', validPayShopCallbackPayload([
+        'referencia' => '111111111',
+    ])));
+
+    $response->assertStatus(422)->assertJsonStructure(['referencia']);
+});
+
+it('rejects a PayShop callback from an unknown channel', function () {
+    $response = $this->getJson(route('eupago.payshop.callback', validPayShopCallbackPayload([
+        'canal' => 'someone-else',
+    ])));
+
+    $response->assertStatus(422)->assertJsonStructure(['canal']);
+});
+
+it('rejects a PayShop callback with an invalid api key', function () {
+    $response = $this->getJson(route('eupago.payshop.callback', validPayShopCallbackPayload([
+        'chave_api' => 'wrong-key',
+    ])));
+
+    $response->assertStatus(422)->assertJsonStructure(['chave_api']);
+});
+
+it('rejects a PayShop callback missing required fields', function () {
+    $response = $this->getJson(route('eupago.payshop.callback', ['valor' => '20.00']));
+
+    $response->assertStatus(422);
+});

--- a/tests/Feature/PayShopCreationTest.php
+++ b/tests/Feature/PayShopCreationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use CodeTech\EuPago\PayShop\PayShop;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+it('creates a PayShop reference and maps the response keys', function () {
+    Http::fake(['*' => Http::response([
+        'sucesso' => true,
+        'estado' => 0,
+        'resposta' => 'OK',
+        'referencia' => 555444333,
+        'valor' => '20.00',
+    ])]);
+
+    $result = (new PayShop(20.00, '555'))->create();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['reference'])->toBe(555444333)
+        ->and($result['value'])->toBe('20.00');
+});
+
+it('sends the PayShop creation request with the configured credentials', function () {
+    Http::fake(['*' => Http::response(['sucesso' => true])]);
+
+    (new PayShop(20.00, '555'))->create();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'payshop/create')
+        && $request['chave'] === config('eupago.api_key')
+        && $request['valor'] == 20.00);
+});
+
+it('throws when the PayShop API returns a server error', function () {
+    Http::fake(['*' => Http::response('Server Error', 500)]);
+
+    expect(fn () => (new PayShop(20.00, '555'))->create())->toThrow(RequestException::class);
+});
+
+it('records an error when the PayShop API reports failure', function () {
+    Http::fake(['*' => Http::response([
+        'sucesso' => false,
+        'estado' => 13,
+        'resposta' => 'Erro',
+    ])]);
+
+    $payShop = new PayShop(20.00, '555');
+    $payShop->create();
+
+    expect($payShop->hasErrors())->toBeTrue()
+        ->and($payShop->getErrors())->toHaveKey(13);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 use CodeTech\EuPago\Models\MbReference;
 use CodeTech\EuPago\Models\MbwayReference;
+use CodeTech\EuPago\Models\PayShopReference;
 use CodeTech\EuPago\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
@@ -84,5 +85,36 @@ function validMbwayCallbackPayload(array $overrides = []): array
         'data' => now()->format('Y-m-d:H:i:s'),
         'entidade' => '54321',
         'comissao' => '0.30',
+    ], $overrides);
+}
+
+function createPendingPayShopReference(array $overrides = []): PayShopReference
+{
+    $reference = new PayShopReference(array_merge([
+        'reference' => 555444333,
+        'value' => 20.00,
+        'state' => 0,
+    ], $overrides));
+
+    $reference->payshopable_id = 1;
+    $reference->payshopable_type = 'Tests\\Dummy';
+    $reference->save();
+
+    return $reference;
+}
+
+function validPayShopCallbackPayload(array $overrides = []): array
+{
+    return array_merge([
+        'valor' => '20.00',
+        'canal' => config('eupago.channel'),
+        'referencia' => '555444333',
+        'transacao' => 'TXN555',
+        'identificador' => 'ID555',
+        'mp' => 'PS',
+        'chave_api' => config('eupago.api_key'),
+        'data' => now()->format('Y-m-d:H:i:s'),
+        'entidade' => '00000',
+        'comissao' => '0.20',
     ], $overrides);
 }

--- a/tests/Unit/PayShopReferenceTest.php
+++ b/tests/Unit/PayShopReferenceTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use CodeTech\EuPago\Models\PayShopReference;
+
+it('scopes a query to paid references only', function () {
+    createPendingPayShopReference(['reference' => 111, 'state' => 0]);
+    createPendingPayShopReference(['reference' => 222, 'state' => 1]);
+
+    expect(PayShopReference::paid()->count())->toBe(1);
+});
+
+it('casts value to float and state to integer', function () {
+    $reference = createPendingPayShopReference(['value' => 12, 'state' => 1])->fresh();
+
+    expect($reference->value)->toBeFloat()->toBe(12.0)
+        ->and($reference->state)->toBeInt()->toBe(1);
+});


### PR DESCRIPTION
### Description

- feat(payshop): add PayShop reference support
- test(payshop): cover PayShop create, callback, and model flows
- docs(readme): document PayShop usage and callback


### Fixes

Closes #36




