### PR TITLE
feat(routes): add config toggle for callback route registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,36 @@ There are two environments available for you to use: "test" and "prod". As you m
 you can use the "test" environment during the development stage of your application. Switch to "prod"
 environment when your application is ready for production.
 
+### Routes
+
+The package supports two levels of usage:
+
+- **Full integration** (default): use the traits and models to persist references, and let the
+  package handle EuPago's webhooks — it registers the callback routes (`/eupago/*/callback`)
+  automatically.
+- **Thin API client**: use only the payment classes (e.g. `new MB(...)->create()`) and handle
+  persistence and webhooks yourself.
+
+If you only need the thin client, disable the automatic route registration:
+
+```
+EUPAGO_ROUTES=false
+```
+
+With the routes disabled you can still mount the package's callback controllers on routes of
+your own, giving you full control over the path and middleware:
+
+```
+use CodeTech\EuPago\Http\Controllers\MBController;
+
+Route::get('webhooks/eupago/mb', [MBController::class, 'callback'])
+    ->middleware('web')
+    ->name('eupago.mb.callback');
+```
+
+> **Note:** if your application caches routes, run `php artisan route:clear` after changing
+> this setting.
+
 ### MB References
 
 #### Usage

--- a/config/eupago.php
+++ b/config/eupago.php
@@ -35,4 +35,17 @@ return [
 
     'channel' => env('EUPAGO_CHANNEL', 'demo'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Routes
+    |--------------------------------------------------------------------------
+    |
+    | The package automatically registers the payment callback routes
+    | (e.g. /eupago/mb/callback). Disable this if you use the package as
+    | a thin API client and handle EuPago's webhooks yourself.
+    |
+    */
+
+    'routes' => (bool) env('EUPAGO_ROUTES', true),
+
 ];

--- a/src/Providers/EuPagoServiceProvider.php
+++ b/src/Providers/EuPagoServiceProvider.php
@@ -47,6 +47,10 @@ class EuPagoServiceProvider extends ServiceProvider
      */
     private function loadRoutes()
     {
+        if (! $this->app['config']->get('eupago.routes')) {
+            return;
+        }
+
         if ($this->app->routesAreCached()) {
             return;
         }

--- a/tests/Feature/PackageBootTest.php
+++ b/tests/Feature/PackageBootTest.php
@@ -5,8 +5,9 @@ it('merges the eupago config when the package boots', function () {
         ->and(config('eupago.channel'))->toBe('demo');
 });
 
-it('registers the eupago callback routes', function () {
-    expect(app('router')->has('eupago.mb.callback'))->toBeTrue()
+it('registers the eupago callback routes by default', function () {
+    expect(config('eupago.routes'))->toBeTrue()
+        ->and(app('router')->has('eupago.mb.callback'))->toBeTrue()
         ->and(app('router')->has('eupago.mbway.callback'))->toBeTrue()
         ->and(app('router')->has('eupago.payshop.callback'))->toBeTrue();
 });

--- a/tests/Feature/RoutesDisabledTest.php
+++ b/tests/Feature/RoutesDisabledTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CodeTech\EuPago\Tests\Feature;
+
+use CodeTech\EuPago\Tests\TestCase;
+
+/**
+ * A class-based test (instead of a Pest closure) because the config must be
+ * set before the service provider boots.
+ */
+class RoutesDisabledTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('eupago.routes', false);
+    }
+
+    public function test_no_callback_routes_are_registered_when_routes_are_disabled(): void
+    {
+        $this->assertFalse(app('router')->has('eupago.mb.callback'));
+        $this->assertFalse(app('router')->has('eupago.mbway.callback'));
+        $this->assertFalse(app('router')->has('eupago.payshop.callback'));
+
+        $this->getJson('/eupago/mb/callback')->assertNotFound();
+    }
+}


### PR DESCRIPTION
Closes #53.

The service provider registered the callback routes unconditionally, so consumers using the package as a thin API client (payment classes only, own persistence/webhooks) still got `/eupago/*/callback` endpoints mounted. Routes were the only package piece that couldn't be opted out of — migrations and config are already publish-only.

## Changes

- New `routes` config key (default `true`, env `EUPAGO_ROUTES`); `EuPagoServiceProvider::loadRoutes()` returns early when disabled — same gating pattern as Telescope/Horizon. Non-breaking: `mergeConfigFrom()` supplies the default for consumers with an already-published config, so no re-publish is needed.
- Tests: default-on assertion added to the boot test; new `RoutesDisabledTest` (class-based, since the config must be set before the provider boots) asserts no routes are registered and the callback URL 404s.
- README: documents the toggle and frames the two supported usage levels (full integration vs thin API client), including how to mount the package controllers on custom routes with the toggle off.

Deliberately **not** included: route prefix/middleware config keys — with the toggle, consumers get full path/middleware control by registering the controllers themselves; knobs can be added later (non-breaking) if a concrete need shows up.