### PR TITLE
docs(upgrade): correct PaysafeCard release version to v3.5.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrading
 
-## From v3.3.x to v3.4.0
+## From v3.4.x to v3.5.0
 
 This release adds PaysafeCard support, which uses a new `paysafecard_references` table. Re-publish the migrations (existing files are left untouched) and run the new one:
 


### PR DESCRIPTION
Closes #55.

The PaysafeCard UPGRADE entry was headed "From v3.3.x to v3.4.0", but v3.4.0/v3.4.1 were already tagged on 2026-06-27 (#48, #51). The unreleased changes on master (PaysafeCard support #52, route toggle #54) ship as v3.5.0.