### PR TITLE
docs(community): add CONTRIBUTING and SECURITY policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ composer lint      # Pint code-style check (run `composer format` to fix)
 composer analyse   # PHPStan static analysis
 ```
 
-- Add tests for any change in behaviour. Tests are written with Pest and live in `tests/Feature`.
+- Add tests for any change in behaviour. Tests are written with Pest — unit tests live in `tests/Unit`, feature tests in `tests/Feature`.
 - Keep pull requests focused: one feature or fix per PR.
 - Use a [conventional-commit](https://www.conventionalcommits.org) style title, e.g. `fix(mbway): handle missing alias`.
 - Reference the related issue in the PR description. If there is no issue yet, please open one first so the change can be discussed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thanks for considering contributing to **codetech/laravel-eupago**!
+
+## Which branch?
+
+- **New features and improvements**: target the [`master`](https://github.com/CodeTechAgency/laravel-eupago/tree/master) branch (3.x, Laravel 10–11).
+- **Security fixes for the 2.x line**: target the [`2.x`](https://github.com/CodeTechAgency/laravel-eupago/tree/2.x) branch. No other changes are accepted there.
+- The [`1.x`](https://github.com/CodeTechAgency/laravel-eupago/tree/1.x) branch is end-of-life and receives no changes.
+
+## Getting started
+
+```bash
+git clone git@github.com:CodeTechAgency/laravel-eupago.git
+cd laravel-eupago
+composer install
+```
+
+## Before submitting a pull request
+
+Run the full quality suite locally — CI runs the same checks:
+
+```bash
+composer test      # Pest test suite
+composer lint      # Pint code-style check (run `composer format` to fix)
+composer analyse   # PHPStan static analysis
+```
+
+- Add tests for any change in behaviour. Tests are written with Pest and live in `tests/Feature`.
+- Keep pull requests focused: one feature or fix per PR.
+- Use a [conventional-commit](https://www.conventionalcommits.org) style title, e.g. `fix(mbway): handle missing alias`.
+- Reference the related issue in the PR description. If there is no issue yet, please open one first so the change can be discussed.
+
+## Reporting bugs
+
+Open an issue using the bug report template and include the package, Laravel and PHP versions plus the smallest reproduction you can manage.
+
+**Security vulnerabilities must not be reported publicly** — see the [security policy](https://github.com/CodeTechAgency/laravel-eupago/blob/master/SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ client** (payment classes only) — see [Routes](#routes) for how to switch.
 - [Testing & code quality](#testing--code-quality)
 - [Upgrading](#upgrading)
 - [Changelog](#changelog)
+- [Contributing](#contributing)
+- [Security](#security)
 - [Support](#support)
 - [License](#license)
 
@@ -492,6 +494,14 @@ for information on how to upgrade between versions.
 ## Changelog
 
 Every release is documented on the [GitHub releases page](https://github.com/CodeTechAgency/laravel-eupago/releases).
+
+## Contributing
+
+Contributions are welcome! Please read the [contributing guidelines](https://github.com/CodeTechAgency/laravel-eupago/blob/master/CONTRIBUTING.md) before opening an issue or pull request.
+
+## Security
+
+If you discover a security vulnerability, please follow the [security policy](https://github.com/CodeTechAgency/laravel-eupago/blob/master/SECURITY.md) — do not report it publicly.
 
 ## Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 3.x | ✅ Active support |
+| 2.x | ⚠️ Security fixes only |
+| 1.x | ❌ End of life |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report them privately via [GitHub Security Advisories](https://github.com/CodeTechAgency/laravel-eupago/security/advisories/new). If that is not an option, email the maintainer at jfrosorio@gmail.com.
+
+You will receive a response as soon as possible. Once the issue is confirmed, a fix is prepared for all supported versions and released together with an advisory crediting the reporter (unless you prefer to remain anonymous).


### PR DESCRIPTION
Closes #59.

Adopts the community-files standard from codetech/laravel-api-logs:

- **CONTRIBUTING.md**: branch targeting (`master` = 3.x active, `2.x` = security fixes only, `1.x` = EOL), getting-started steps, the composer quality suite (`test`/`lint`/`analyse` — all scripts already exist), conventional-commit PR titles, issue-first policy, security redirect.
- **SECURITY.md**: supported-versions table matching that policy; private reporting via GitHub Security Advisories with email fallback.
- README: Contributing and Security sections (+ ToC entries) linking the new files.

Stacked on #58 (both touch the README); GitHub will retarget this PR to `master` automatically once #58 merges.