### PR TITLE
test(phpunit): split Unit and Feature testsuites

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,11 @@
          colors="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
-        <testsuite name="EuPago Test Suite">
-            <directory>tests</directory>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
Closes #61.

The test directories were already split (`tests/Unit`, `tests/Feature`) but `phpunit.xml` declared a single suite covering `tests/`. Declared the two suites so `--testsuite=Unit` / `--testsuite=Feature` filtering works and CI can target suites individually, matching Laravel conventions and the CONTRIBUTING wording.

Verified: full run 71 passed (9 Unit + 62 Feature); both suite filters run the expected subset.