### PR TITLE
chore(composer): refresh keywords and description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,16 @@
 {
   "name": "codetech/laravel-eupago",
-  "description": "A Laravel package for making payments through the EuPago API.",
+  "description": "Eupago payment gateway integration for Laravel — Multibanco, MB WAY, PayShop and PaysafeCard payments.",
   "keywords": [
-    "eupago",
-    "referências multibanco",
-    "mb references",
-    "mbway references",
-    "laravel-eupago",
     "laravel",
-    "codetech"
+    "eupago",
+    "payment",
+    "payment-gateway",
+    "multibanco",
+    "mbway",
+    "payshop",
+    "paysafecard",
+    "portugal"
   ],
   "authors": [
     {


### PR DESCRIPTION
Closes #63.

- **Keywords**: replaced multi-word/accented phrases ("mb references", "referências multibanco") and the redundant "laravel-eupago" with the single lowercase tokens people actually search — all four payment methods (`multibanco`, `mbway`, `payshop`, `paysafecard`) plus `payment`, `payment-gateway`, `portugal`. Aligned with the GitHub repo topics.
- **Description**: adopts the banner's line ("Eupago payment gateway integration for Laravel") with the supported methods spelled out; also moves off the old "EuPago" prose casing.

`composer validate` passes. Packagist will surface the new metadata fully with the next tagged release.