### PR TITLE
feat(laravel): add Laravel 12 and 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Laravel 10 supports PHP 8.1–8.3; Laravel 11 supports PHP 8.2+.
+        # PHP support: Laravel 10 → 8.1–8.3; Laravel 11 → 8.2+; Laravel 12 → 8.2+;
+        # Laravel 13 → 8.3+. Pest resolves per row (2.x on Laravel 10, 3.x on 11+).
         include:
           - { php: '8.1', laravel: '10.*', testbench: '8.*' }
           - { php: '8.2', laravel: '10.*', testbench: '8.*' }
           - { php: '8.3', laravel: '10.*', testbench: '8.*' }
           - { php: '8.2', laravel: '11.*', testbench: '9.*' }
           - { php: '8.3', laravel: '11.*', testbench: '9.*' }
+          - { php: '8.4', laravel: '11.*', testbench: '9.*' }
+          - { php: '8.2', laravel: '12.*', testbench: '10.*' }
+          - { php: '8.3', laravel: '12.*', testbench: '10.*' }
+          - { php: '8.4', laravel: '12.*', testbench: '10.*' }
+          - { php: '8.3', laravel: '13.*', testbench: '11.*' }
+          - { php: '8.4', laravel: '13.*', testbench: '11.*' }
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         # PHP support: Laravel 10 → 8.1–8.3; Laravel 11 → 8.2+; Laravel 12 → 8.2+;
-        # Laravel 13 → 8.3+. Pest resolves per row (2.x on Laravel 10, 3.x on 11+).
+        # Laravel 13 → 8.3+. The Testbench pin also deterministically selects the
+        # Pest major: Testbench 8 conflicts with PHPUnit >=10.6 while Pest 3 needs
+        # PHPUnit ^11.5, so Laravel 10 rows always get Pest 2; Testbench 9+ rows
+        # resolve Pest 3.
         include:
           - { php: '8.1', laravel: '10.*', testbench: '8.*' }
           - { php: '8.2', laravel: '10.*', testbench: '8.*' }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ client** (payment classes only) — see [Routes](#routes) for how to switch.
 
 | Package version                                                          | Laravel | PHP     | Status         |
 |--------------------------------------------------------------------------|---------|---------|----------------|
-| 3.x (`master`)                                                           | 10 / 11 | ≥ 8.1   | Active         |
+| 3.x (`master`)                                                           | 10 – 13 | ≥ 8.1   | Active         |
 | 2.x ([`2.x`](https://github.com/CodeTechAgency/laravel-eupago/tree/2.x)) | 9 / 10  | ≥ 8.0.2 | Security fixes |
 | 1.x ([`1.x`](https://github.com/CodeTechAgency/laravel-eupago/tree/1.x)) | 8       | ≥ 8.0   | End of life    |
 

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
   "require": {
     "php": "^8.1",
     "guzzlehttp/guzzle": "^7.0",
-    "illuminate/broadcasting": "^10.0|^11.0",
-    "illuminate/database": "^10.0|^11.0",
-    "illuminate/http": "^10.0|^11.0",
-    "illuminate/log": "^10.0|^11.0",
-    "illuminate/queue": "^10.0|^11.0",
-    "illuminate/routing": "^10.0|^11.0",
-    "illuminate/support": "^10.0|^11.0",
-    "illuminate/validation": "^10.0|^11.0",
+    "illuminate/broadcasting": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/log": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
     "nesbot/carbon": "^2.0|^3.0"
   },
   "autoload": {
@@ -53,10 +53,10 @@
     }
   },
   "require-dev": {
-    "larastan/larastan": "^2.9",
+    "larastan/larastan": "^2.9|^3.0",
     "laravel/pint": "^1.0",
-    "orchestra/testbench": "^8.0|^9.0",
-    "pestphp/pest": "^2.36"
+    "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+    "pestphp/pest": "^2.36|^3.0"
   },
   "config": {
     "allow-plugins": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,3 +13,9 @@ parameters:
         -
             message: '#Unsafe usage of new static\(\)\.#'
             path: src/Events/Dispatchable.php
+
+        # The package's traits are consumed by the host application's models,
+        # so within src/ they are legitimately "unused" (PHPStan 2 rule).
+        -
+            identifier: trait.unused
+            path: src/Traits/*


### PR DESCRIPTION
Closes #65.

Additive constraint widening — no consumer-facing changes beyond installability on Laravel 12/13.

## Changes

- `illuminate/*` widened to `^10.0|^11.0|^12.0|^13.0`; PHP floor stays `^8.1` (composer resolves per-install)
- Dev deps OR-widened: Testbench `^8–^11`, Pest `^2.36|^3.0`, Larastan `^2.9|^3.0` — Pest 2 keeps covering the Laravel 10 rows, Pest 3 covers 11–13 (Testbench 11 accepts PHPUnit ^11.5)
- CI matrix extended to 11 rows: adds Laravel 12 (PHP 8.2/8.3/8.4, Testbench 10), Laravel 13 (PHP 8.3/8.4, Testbench 11), and PHP 8.4 on Laravel 11
- `phpstan.neon`: ignore PHPStan 2's new `trait.unused` rule for `src/Traits/*` — the package's traits are consumed by host applications, so they're legitimately unused within `src/`
- README Requirements table: 3.x → Laravel 10–13

## Verification

Locally on the highest combo (PHP 8.4, Laravel 13, Testbench 11, Pest 3.8, PHPStan 2): all 71 tests pass unchanged, Pint clean, PHPStan clean. The remaining matrix rows are proven by CI on this PR.

Note: tests intentionally stay Pest-2-compatible until v4 (Laravel 10 rows resolve Pest 2).