### PR TITLE
refactor(traits): rename to Has*References with deprecated aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,15 +183,15 @@ try {
 ]
 ```
 
-Alternatively, use the `Mbable` trait on the models for which you want to generate MB
-references:
+Alternatively, use the `HasMultibancoReferences` trait on the models for which you want
+to generate MB references:
 
 ```php
-use CodeTech\EuPago\Traits\Mbable;
+use CodeTech\EuPago\Traits\HasMultibancoReferences;
 
 class Order extends Model
 {
-    use Mbable;
+    use HasMultibancoReferences;
 }
 ```
 
@@ -240,14 +240,14 @@ try {
 }
 ```
 
-Alternatively, use the `Mbwayable` trait:
+Alternatively, use the `HasMbWayReferences` trait:
 
 ```php
-use CodeTech\EuPago\Traits\Mbwayable;
+use CodeTech\EuPago\Traits\HasMbWayReferences;
 
 class Order extends Model
 {
-    use Mbwayable;
+    use HasMbWayReferences;
 }
 ```
 
@@ -302,14 +302,14 @@ try {
 ]
 ```
 
-Alternatively, use the `PayShopable` trait:
+Alternatively, use the `HasPayShopReferences` trait:
 
 ```php
-use CodeTech\EuPago\Traits\PayShopable;
+use CodeTech\EuPago\Traits\HasPayShopReferences;
 
 class Order extends Model
 {
-    use PayShopable;
+    use HasPayShopReferences;
 }
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrading
 
+## From v3.5.x to v3.6.0
+
+The `*able` traits are deprecated in favour of `Has*References` names (matching `HasPaysafeCardReferences`). The old names keep working as aliases until v4 — no behavior change — but you should update your models:
+
+| Deprecated | Use instead |
+|------------|-------------|
+| `Mbable` | `HasMultibancoReferences` |
+| `Mbwayable` | `HasMbWayReferences` |
+| `PayShopable` | `HasPayShopReferences` |
+
 ## From v3.4.x to v3.5.0
 
 This release adds PaysafeCard support, which uses a new `paysafecard_references` table. Re-publish the migrations (existing files are left untouched) and run the new one:

--- a/src/Traits/HasMbWayReferences.php
+++ b/src/Traits/HasMbWayReferences.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CodeTech\EuPago\Traits;
+
+use CodeTech\EuPago\MBWay\MBWay;
+use CodeTech\EuPago\Models\MbwayReference;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+
+trait HasMbWayReferences
+{
+    use CreatesEuPagoReferences;
+
+    /**
+     * Get all of the models' MB Way references.
+     */
+    public function mbwayReferences()
+    {
+        return $this->morphMany(MbwayReference::class, 'mbwayable');
+    }
+
+    /**
+     * Creates and persists an MB Way reference.
+     *
+     * @return Model|array the persisted reference, or the errors on failure
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    public function createMbwayReference(float $value, int $id, string $alias, ?string $description = null)
+    {
+        return $this->persistReference(
+            new MBWay($value, $id, $alias, $description),
+            'mbwayReferences'
+        );
+    }
+}

--- a/src/Traits/HasMbWayReferences.php
+++ b/src/Traits/HasMbWayReferences.php
@@ -13,7 +13,7 @@ trait HasMbWayReferences
     use CreatesEuPagoReferences;
 
     /**
-     * Get all of the models' MB Way references.
+     * Get all of the model's MB Way references.
      */
     public function mbwayReferences()
     {

--- a/src/Traits/HasMultibancoReferences.php
+++ b/src/Traits/HasMultibancoReferences.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CodeTech\EuPago\Traits;
+
+use Carbon\Carbon;
+use CodeTech\EuPago\MB\MB;
+use CodeTech\EuPago\Models\MbReference;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+
+trait HasMultibancoReferences
+{
+    use CreatesEuPagoReferences;
+
+    /**
+     * Get all of the model's MB references.
+     */
+    public function mbReferences()
+    {
+        return $this->morphMany(MbReference::class, 'mbable');
+    }
+
+    /**
+     * Creates and persists an MB reference.
+     *
+     * @return Model|array the persisted reference, or the errors on failure
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    public function createMbReference(float $value, string $id, Carbon $startDate, Carbon $endDate, float $minValue, float $maxValue, bool $allowDuplication = false)
+    {
+        return $this->persistReference(
+            new MB($value, $id, $startDate, $endDate, $minValue, $maxValue, $allowDuplication),
+            'mbReferences'
+        );
+    }
+}

--- a/src/Traits/HasPayShopReferences.php
+++ b/src/Traits/HasPayShopReferences.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CodeTech\EuPago\Traits;
+
+use CodeTech\EuPago\Models\PayShopReference;
+use CodeTech\EuPago\PayShop\PayShop;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+
+trait HasPayShopReferences
+{
+    use CreatesEuPagoReferences;
+
+    /**
+     * Get all of the model's PayShop references.
+     */
+    public function payShopReferences()
+    {
+        return $this->morphMany(PayShopReference::class, 'payshopable');
+    }
+
+    /**
+     * Creates and persists a PayShop reference.
+     *
+     * @return Model|array the persisted reference, or the errors on failure
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    public function createPayShopReference(float $value, string $id)
+    {
+        return $this->persistReference(
+            new PayShop($value, $id),
+            'payShopReferences'
+        );
+    }
+}

--- a/src/Traits/Mbable.php
+++ b/src/Traits/Mbable.php
@@ -2,38 +2,10 @@
 
 namespace CodeTech\EuPago\Traits;
 
-use Carbon\Carbon;
-use CodeTech\EuPago\MB\MB;
-use CodeTech\EuPago\Models\MbReference;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\RequestException;
-
+/**
+ * @deprecated Use HasMultibancoReferences instead. Will be removed in v4.
+ */
 trait Mbable
 {
-    use CreatesEuPagoReferences;
-
-    /**
-     * Get all of the model's MB references.
-     */
-    public function mbReferences()
-    {
-        return $this->morphMany(MbReference::class, 'mbable');
-    }
-
-    /**
-     * Creates and persists an MB reference.
-     *
-     * @return Model|array the persisted reference, or the errors on failure
-     *
-     * @throws ConnectionException
-     * @throws RequestException
-     */
-    public function createMbReference(float $value, string $id, Carbon $startDate, Carbon $endDate, float $minValue, float $maxValue, bool $allowDuplication = false)
-    {
-        return $this->persistReference(
-            new MB($value, $id, $startDate, $endDate, $minValue, $maxValue, $allowDuplication),
-            'mbReferences'
-        );
-    }
+    use HasMultibancoReferences;
 }

--- a/src/Traits/Mbwayable.php
+++ b/src/Traits/Mbwayable.php
@@ -2,37 +2,10 @@
 
 namespace CodeTech\EuPago\Traits;
 
-use CodeTech\EuPago\MBWay\MBWay;
-use CodeTech\EuPago\Models\MbwayReference;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\RequestException;
-
+/**
+ * @deprecated Use HasMbWayReferences instead. Will be removed in v4.
+ */
 trait Mbwayable
 {
-    use CreatesEuPagoReferences;
-
-    /**
-     * Get all of the models' MB Way references.
-     */
-    public function mbwayReferences()
-    {
-        return $this->morphMany(MbwayReference::class, 'mbwayable');
-    }
-
-    /**
-     * Creates and persists an MB Way reference.
-     *
-     * @return Model|array the persisted reference, or the errors on failure
-     *
-     * @throws ConnectionException
-     * @throws RequestException
-     */
-    public function createMbwayReference(float $value, int $id, string $alias, ?string $description = null)
-    {
-        return $this->persistReference(
-            new MBWay($value, $id, $alias, $description),
-            'mbwayReferences'
-        );
-    }
+    use HasMbWayReferences;
 }

--- a/src/Traits/PayShopable.php
+++ b/src/Traits/PayShopable.php
@@ -2,37 +2,10 @@
 
 namespace CodeTech\EuPago\Traits;
 
-use CodeTech\EuPago\Models\PayShopReference;
-use CodeTech\EuPago\PayShop\PayShop;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\RequestException;
-
+/**
+ * @deprecated Use HasPayShopReferences instead. Will be removed in v4.
+ */
 trait PayShopable
 {
-    use CreatesEuPagoReferences;
-
-    /**
-     * Get all of the model's PayShop references.
-     */
-    public function payShopReferences()
-    {
-        return $this->morphMany(PayShopReference::class, 'payshopable');
-    }
-
-    /**
-     * Creates and persists a PayShop reference.
-     *
-     * @return Model|array the persisted reference, or the errors on failure
-     *
-     * @throws ConnectionException
-     * @throws RequestException
-     */
-    public function createPayShopReference(float $value, string $id)
-    {
-        return $this->persistReference(
-            new PayShop($value, $id),
-            'payShopReferences'
-        );
-    }
+    use HasPayShopReferences;
 }

--- a/tests/Feature/TraitHelpersTest.php
+++ b/tests/Feature/TraitHelpersTest.php
@@ -4,7 +4,10 @@ use CodeTech\EuPago\Models\MbReference;
 use CodeTech\EuPago\Models\MbwayReference;
 use CodeTech\EuPago\Models\PaysafeCardReference;
 use CodeTech\EuPago\Models\PayShopReference;
+use CodeTech\EuPago\Traits\HasMbWayReferences;
+use CodeTech\EuPago\Traits\HasMultibancoReferences;
 use CodeTech\EuPago\Traits\HasPaysafeCardReferences;
+use CodeTech\EuPago\Traits\HasPayShopReferences;
 use CodeTech\EuPago\Traits\Mbable;
 use CodeTech\EuPago\Traits\Mbwayable;
 use CodeTech\EuPago\Traits\PayShopable;
@@ -15,7 +18,21 @@ use Illuminate\Support\Facades\Schema;
 
 class DummyPayable extends Model
 {
-    use HasPaysafeCardReferences, Mbable, Mbwayable, PayShopable;
+    use HasMbWayReferences, HasMultibancoReferences, HasPaysafeCardReferences, HasPayShopReferences;
+
+    protected $table = 'dummy_payables';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}
+
+/**
+ * Uses the deprecated trait aliases — guards backwards compatibility until v4.
+ */
+class DummyLegacyPayable extends Model
+{
+    use Mbable, Mbwayable, PayShopable;
 
     protected $table = 'dummy_payables';
 
@@ -98,4 +115,20 @@ it('returns the errors and persists nothing when the API reports failure', funct
     expect($result)->toBeArray()
         ->and($result)->toHaveKey(11)
         ->and($this->payable->payShopReferences()->count())->toBe(0);
+});
+
+it('keeps the deprecated trait aliases working until v4', function () {
+    $legacy = DummyLegacyPayable::create();
+
+    Http::fake(['*' => Http::response([
+        'sucesso' => true, 'estado' => 0, 'resposta' => 'OK',
+        'referencia' => '555444333', 'valor' => 20.00,
+    ])]);
+
+    $reference = $legacy->createPayShopReference(20.00, '1');
+
+    expect($reference)->toBeInstanceOf(PayShopReference::class)
+        ->and($legacy->payShopReferences()->count())->toBe(1)
+        ->and($legacy->mbReferences()->count())->toBe(0)
+        ->and($legacy->mbwayReferences()->count())->toBe(0);
 });


### PR DESCRIPTION
Closes #67.

Completes the trait naming convention started with `HasPaysafeCardReferences` (v3.5.0), without waiting for v4 and without breaking anyone:

- `Mbable` → `HasMultibancoReferences`, `Mbwayable` → `HasMbWayReferences`, `PayShopable` → `HasPayShopReferences` (files `git mv`'d so history follows)
- Old names remain as `@deprecated` one-line bridge traits (`trait Mbable { use HasMultibancoReferences; }`) — removed in v4
- Method names (`mbReferences()`, `createMbReference()`, …) and morph names intentionally unchanged
- README documents the new names only; UPGRADE.md gets a v3.6.0 deprecation table
- New test guards the aliases keep wiring the relationships until v4

72 tests green, Pint and PHPStan clean.