### PR TITLE
fix(mbway): store reference value as decimal for callback matching

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,7 @@ The `*able` traits are deprecated in favour of `Has*References` names (matching 
 | `Mbwayable` | `HasMbWayReferences` |
 | `PayShopable` | `HasPayShopReferences` |
 
-The `mbway_references.value` column changes from FLOAT to DECIMAL(10,2) so callback matching can never miss a payment to float rounding. Re-publish the migrations and run the new one:
+The `mbway_references.value` column changes from FLOAT to DECIMAL(10,2) so callback matching can never miss a payment due to float rounding. Re-publish the migrations and run the new one:
 
 ```bash
 php artisan vendor:publish --provider=CodeTech\\EuPago\\Providers\\EuPagoServiceProvider --tag=migrations

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,6 +10,15 @@ The `*able` traits are deprecated in favour of `Has*References` names (matching 
 | `Mbwayable` | `HasMbWayReferences` |
 | `PayShopable` | `HasPayShopReferences` |
 
+The `mbway_references.value` column changes from FLOAT to DECIMAL(10,2) so callback matching can never miss a payment to float rounding. Re-publish the migrations and run the new one:
+
+```bash
+php artisan vendor:publish --provider=CodeTech\\EuPago\\Providers\\EuPagoServiceProvider --tag=migrations
+php artisan migrate
+```
+
+> **Laravel 10 apps only:** the column-change migration needs `doctrine/dbal` (`composer require doctrine/dbal`). Laravel 11+ changes columns natively.
+
 ## From v3.4.x to v3.5.0
 
 This release adds PaysafeCard support, which uses a new `paysafecard_references` table. Re-publish the migrations (existing files are left untouched) and run the new one:

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     }
   },
   "require-dev": {
+    "doctrine/dbal": "^3.6",
     "larastan/larastan": "^2.9|^3.0",
     "laravel/pint": "^1.0",
     "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",

--- a/database/migrations/2020_09_01_080749_create_mbway_references_table.php
+++ b/database/migrations/2020_09_01_080749_create_mbway_references_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('mbway_references', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('reference')->unique();
-            $table->float('value', 10, 2)->default(0);
+            $table->decimal('value', 10, 2)->default(0);
             $table->string('alias');
             $table->integer('state')->default(0);
             $table->morphs('mbwayable');

--- a/database/migrations/2026_07_15_000000_change_mbway_references_value_to_decimal.php
+++ b/database/migrations/2026_07_15_000000_change_mbway_references_value_to_decimal.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * The value was stored as FLOAT, and the callback matches the paid
+     * reference with an equality lookup — float rounding could make a
+     * legitimate callback miss the row, leaving a real payment pending.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mbway_references', function (Blueprint $table) {
+            $table->decimal('value', 10, 2)->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mbway_references', function (Blueprint $table) {
+            $table->float('value')->default(0)->change();
+        });
+    }
+};

--- a/database/migrations/2026_07_15_000000_change_mbway_references_value_to_decimal.php
+++ b/database/migrations/2026_07_15_000000_change_mbway_references_value_to_decimal.php
@@ -25,6 +25,10 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      *
+     * The original column was FLOAT(10,2), but MySQL deprecated FLOAT(M,D)
+     * in 8.0.17 and Blueprint::float() no longer accepts a scale — a plain
+     * FLOAT is the closest expressible reversal.
+     *
      * @return void
      */
     public function down()


### PR DESCRIPTION
Closes #38.

`mbway_references.value` was FLOAT while the callback matches the paid reference with an equality lookup (`where('value', ...)`) — float rounding on MySQL could make a legitimate callback miss the row and 404, leaving a real payment permanently pending.

## Changes

- Original migration: `value` → `decimal(10, 2)` (fresh installs)
- New `change_mbway_references_value_to_decimal` migration for existing installs
- Audited the sibling tables: `mb_references`, `payshop_references`, and `paysafecard_references` are already `decimal(10,2)` — MB WAY was the only offender
- `doctrine/dbal` added to require-dev so the `->change()` migration runs on the Laravel 10 CI rows (Laravel 11+ changes columns natively)
- UPGRADE entry: re-publish migrations + migrate; Laravel 10 apps need `doctrine/dbal`

The suite exercises the new migration on every run (Testbench loads all package migrations). The float-equality miss itself isn't reproducible on SQLite — the fix is schema-level.

Note: touches the same new UPGRADE section as #68; whichever merges second gets a trivial rebase.