### PR TITLE
feat: OAuth 2.0 authentication and refund support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ client** (payment classes only) — see [Routes](#routes) for how to switch.
   - [PaysafeCard](#paysafecard)
   - [Callbacks](#callbacks)
 - [Querying reference status](#querying-reference-status)
+- [Refunds](#refunds)
 - [Testing & code quality](#testing--code-quality)
 - [Upgrading](#upgrading)
 - [Changelog](#changelog)
@@ -86,6 +87,8 @@ EUPAGO_ENV=test
 EUPAGO_API_KEY=demo-xxxx-xxxx-xxxx-xxx
 EUPAGO_CHANNEL=demo
 EUPAGO_ROUTES=true
+EUPAGO_CLIENT_ID=
+EUPAGO_CLIENT_SECRET=
 ```
 
 ### Environment
@@ -99,6 +102,15 @@ when your application is ready to take real payments.
 `EUPAGO_API_KEY` is the API key of your Eupago channel — you find it in the
 [Eupago backoffice](https://clientes.eupago.pt), where each channel has its own key.
 `EUPAGO_CHANNEL` is the channel name; incoming callbacks are validated against it.
+
+### OAuth client credentials
+
+Eupago's management API — currently used for [refunds](#refunds) — is authenticated with
+OAuth 2.0 bearer tokens instead of the API key. Generate the client credentials in the
+Eupago backoffice and set `EUPAGO_CLIENT_ID` and `EUPAGO_CLIENT_SECRET`. The package
+requests tokens through the client credentials grant and caches them until they expire,
+so you never handle tokens yourself. If you only create references and query their
+status, you can leave these empty.
 
 ### Routes
 
@@ -475,6 +487,52 @@ The `$entity` argument is optional. `$status` is mapped to normalized keys, wher
     'archived' => false,
 ]
 ```
+
+## Refunds
+
+Paid transactions can be refunded, partially or in full, through Eupago's management
+API. Refunds require the [OAuth client credentials](#oauth-client-credentials) to be
+configured. The refund is keyed by the transaction id — the `transacao` value delivered
+by the payment callback:
+
+```php
+use CodeTech\EuPago\EuPago;
+
+$eupago = new EuPago;
+
+try {
+    $result = $eupago->refund($transactionId, 10.50);
+
+    if ($eupago->hasErrors()) {
+        // handle rejection (e.g. refund larger than the payment)
+    }
+} catch (\Exception $e) {
+    // handle exception
+}
+```
+
+`refund()` also accepts an optional reason and, for payment methods without a direct
+refund path, the destination bank account:
+
+```php
+$eupago->refund($transactionId, 10.50, reason: 'duplicate order', iban: 'PT50...', bic: 'BPOTPTPL');
+```
+
+The result is mapped to normalized keys:
+
+```php
+[
+    'success' => true,
+    'status' => "Success",
+    'refund_id' => "12345",
+    'code' => null,
+    'text' => null,
+]
+```
+
+When Eupago rejects the refund (`status` `"Rejected"`), the rejection's `code` and `text`
+are also added to the error bag. Transport and server errors throw, mirroring `create()`
+and `status()`.
 
 ## Testing & code quality
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "php": "^8.1",
     "guzzlehttp/guzzle": "^7.0",
     "illuminate/broadcasting": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/cache": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/log": "^10.0|^11.0|^12.0|^13.0",

--- a/config/eupago.php
+++ b/config/eupago.php
@@ -29,6 +29,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | OAuth 2.0 client credentials
+    |--------------------------------------------------------------------------
+    |
+    | Eupago's management API (refunds, ...) is authenticated with OAuth 2.0
+    | bearer tokens instead of the API key. Generate the client credentials
+    | in the Eupago backoffice. Reference creation and status queries keep
+    | using the API key, so these are only required for management calls.
+    |
+    */
+
+    'client_id' => env('EUPAGO_CLIENT_ID'),
+
+    'client_secret' => env('EUPAGO_CLIENT_SECRET'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Channel
     |--------------------------------------------------------------------------
     */

--- a/src/Auth/TokenProvider.php
+++ b/src/Auth/TokenProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace CodeTech\EuPago\Auth;
+
+use CodeTech\EuPago\EuPago;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class TokenProvider
+{
+    /**
+     * The token endpoint.
+     */
+    const URI = '/api/auth/token';
+
+    /**
+     * Seconds subtracted from the token lifetime when caching, so a cached
+     * token is never handed out right at the edge of its expiry.
+     */
+    const EXPIRY_MARGIN = 60;
+
+    /**
+     * Returns a bearer token for the management API, requesting a new one
+     * when no valid token is cached.
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    public function token(): string
+    {
+        return Cache::get($this->cacheKey()) ?? $this->requestToken();
+    }
+
+    /**
+     * Requests a token through the client credentials grant and caches it
+     * for the lifetime reported by Eupago.
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    protected function requestToken(): string
+    {
+        $response = Http::asForm()->post((new EuPago)->getBaseUri().self::URI, [
+            'client_id' => config('eupago.client_id'),
+            'client_secret' => config('eupago.client_secret'),
+            'grant_type' => 'client_credentials',
+        ])->throw();
+
+        $tokenData = $response->json();
+
+        $token = is_array($tokenData) ? ($tokenData['access_token'] ?? null) : null;
+
+        if (! is_string($token) || $token === '') {
+            throw new \RuntimeException('The Eupago token response did not contain an access token.');
+        }
+
+        $expiresIn = (int) ($tokenData['expires_in'] ?? 0);
+
+        if ($expiresIn > self::EXPIRY_MARGIN) {
+            Cache::put($this->cacheKey(), $token, $expiresIn - self::EXPIRY_MARGIN);
+        }
+
+        return $token;
+    }
+
+    /**
+     * Returns the cache key holding the token, scoped so switching the
+     * environment or the client never reuses a stale token.
+     */
+    protected function cacheKey(): string
+    {
+        return 'eupago.token.'.md5(config('eupago.env').'|'.config('eupago.client_id'));
+    }
+}

--- a/src/EuPago.php
+++ b/src/EuPago.php
@@ -2,6 +2,7 @@
 
 namespace CodeTech\EuPago;
 
+use CodeTech\EuPago\Auth\TokenProvider;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
@@ -34,6 +35,11 @@ class EuPago
      * endpoint.
      */
     const STATUS_URI = '/clientes/rest_api/multibanco/info';
+
+    /**
+     * The refund endpoint of the management API, keyed by transaction id.
+     */
+    const REFUND_URI = '/api/management/v1.02/refund/';
 
     /**
      * The errors stored during the operations.
@@ -108,6 +114,43 @@ class EuPago
     }
 
     /**
+     * Refunds a transaction, partially or in full. The transaction id is the
+     * `transacao` value delivered by the payment callback.
+     *
+     * Rejections (e.g. a refund larger than the payment) come back as client
+     * errors with a structured body, so they land in the error bag instead of
+     * throwing — only transport and server errors throw.
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    public function refund(int|string $transactionId, float $amount, ?string $reason = null, ?string $iban = null, ?string $bic = null): array
+    {
+        $params = array_filter([
+            'amount' => $amount,
+            'reason' => $reason,
+            'iban' => $iban,
+            'bic' => $bic,
+        ], fn ($value) => $value !== null);
+
+        $response = Http::withToken((new TokenProvider)->token())
+            ->post($this->getBaseUri().static::REFUND_URI.$transactionId, $params)
+            ->throwIfServerError();
+
+        $refundData = $response->json();
+
+        if (! is_array($refundData)) {
+            $refundData = [];
+        }
+
+        if (($refundData['transactionStatus'] ?? null) !== 'Success') {
+            $this->addError($refundData['code'] ?? null, $refundData['text'] ?? null);
+        }
+
+        return $this->mappedRefundKeys($refundData);
+    }
+
+    /**
      * Returns the errors.
      */
     public function getErrors(): array
@@ -145,6 +188,20 @@ class EuPago
     protected function mappedReferenceKeys(array $referenceData): array
     {
         throw new \BadMethodCallException(static::class.' must implement mappedReferenceKeys().');
+    }
+
+    /**
+     * Maps the raw refund response to normalized keys.
+     */
+    protected function mappedRefundKeys(array $refundData): array
+    {
+        return [
+            'success' => ($refundData['transactionStatus'] ?? null) === 'Success',
+            'status' => $refundData['transactionStatus'] ?? null,
+            'refund_id' => $refundData['refundId'] ?? null,
+            'code' => $refundData['code'] ?? null,
+            'text' => $refundData['text'] ?? null,
+        ];
     }
 
     /**

--- a/src/EuPago.php
+++ b/src/EuPago.php
@@ -118,8 +118,9 @@ class EuPago
      * `transacao` value delivered by the payment callback.
      *
      * Rejections (e.g. a refund larger than the payment) come back as client
-     * errors with a structured body, so they land in the error bag instead of
-     * throwing — only transport and server errors throw.
+     * errors with a structured body (transactionStatus present), so they land
+     * in the error bag instead of throwing. Transport and server errors throw,
+     * as do client errors without a structured refund body (e.g. auth failures).
      *
      * @throws ConnectionException
      * @throws RequestException
@@ -141,6 +142,10 @@ class EuPago
 
         if (! is_array($refundData)) {
             $refundData = [];
+        }
+
+        if ($response->clientError() && ! isset($refundData['transactionStatus'])) {
+            $response->throw();
         }
 
         if (($refundData['transactionStatus'] ?? null) !== 'Success') {

--- a/tests/Feature/RefundTest.php
+++ b/tests/Feature/RefundTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use CodeTech\EuPago\EuPago;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+function fakeRefund(array $refundResponse, int $refundStatus = 201): void
+{
+    Http::fake([
+        '*/api/auth/token' => Http::response([
+            'access_token' => 'the-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ]),
+        '*/api/management/*' => Http::response($refundResponse, $refundStatus),
+    ]);
+}
+
+it('refunds a transaction and maps the response keys', function () {
+    fakeRefund(['transactionStatus' => 'Success', 'refundId' => '12345']);
+
+    $eupago = new EuPago;
+    $result = $eupago->refund(987654, 10.50);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['status'])->toBe('Success')
+        ->and($result['refund_id'])->toBe('12345')
+        ->and($eupago->hasErrors())->toBeFalse();
+});
+
+it('sends a bearer-authenticated request keyed by the transaction id', function () {
+    fakeRefund(['transactionStatus' => 'Success', 'refundId' => '12345']);
+
+    (new EuPago)->refund(987654, 10.50);
+
+    Http::assertSent(fn ($request) => str_ends_with($request->url(), '/api/management/v1.02/refund/987654')
+        && $request->hasHeader('Authorization', 'Bearer the-token')
+        && $request['amount'] === 10.5);
+});
+
+it('sends the optional refund details when provided', function () {
+    fakeRefund(['transactionStatus' => 'Success', 'refundId' => '12345']);
+
+    (new EuPago)->refund(987654, 10.50, 'duplicate order', 'PT50000201231234567890154', 'BPOTPTPL');
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/refund/')
+        && $request['reason'] === 'duplicate order'
+        && $request['iban'] === 'PT50000201231234567890154'
+        && $request['bic'] === 'BPOTPTPL');
+});
+
+it('omits the optional refund details when not provided', function () {
+    fakeRefund(['transactionStatus' => 'Success', 'refundId' => '12345']);
+
+    (new EuPago)->refund(987654, 10.50);
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/refund/')
+        && ! isset($request['reason'])
+        && ! isset($request['iban'])
+        && ! isset($request['bic']));
+});
+
+it('records an error when the refund is rejected', function () {
+    fakeRefund([
+        'transactionStatus' => 'Rejected',
+        'code' => 'DIRECT_REFUND_NOT_ALLOWED',
+        'text' => 'Direct Refund Not Allowed',
+    ], 400);
+
+    $eupago = new EuPago;
+    $result = $eupago->refund(987654, 10.50);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['status'])->toBe('Rejected')
+        ->and($result['refund_id'])->toBeNull()
+        ->and($eupago->hasErrors())->toBeTrue()
+        ->and($eupago->getErrors())->toHaveKey('DIRECT_REFUND_NOT_ALLOWED');
+});
+
+it('throws when the refund API returns a server error', function () {
+    fakeRefund([], 500);
+
+    expect(fn () => (new EuPago)->refund(987654, 10.50))->toThrow(RequestException::class);
+});
+
+it('reuses the cached token across refunds', function () {
+    fakeRefund(['transactionStatus' => 'Success', 'refundId' => '12345']);
+
+    (new EuPago)->refund(987654, 10.50);
+    (new EuPago)->refund(987655, 5.00);
+
+    Http::assertSentCount(3);
+});

--- a/tests/Feature/RefundTest.php
+++ b/tests/Feature/RefundTest.php
@@ -77,6 +77,12 @@ it('records an error when the refund is rejected', function () {
         ->and($eupago->getErrors())->toHaveKey('DIRECT_REFUND_NOT_ALLOWED');
 });
 
+it('throws when the refund API returns a client error without a refund body', function () {
+    fakeRefund(['error' => 'invalid_token'], 401);
+
+    expect(fn () => (new EuPago)->refund(987654, 10.50))->toThrow(RequestException::class);
+});
+
 it('throws when the refund API returns a server error', function () {
     fakeRefund([], 500);
 

--- a/tests/Feature/TokenProviderTest.php
+++ b/tests/Feature/TokenProviderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use CodeTech\EuPago\Auth\TokenProvider;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+it('requests a token through the client credentials grant', function () {
+    Http::fake(['*' => Http::response([
+        'access_token' => 'the-token',
+        'token_type' => 'Bearer',
+        'expires_in' => 3600,
+    ])]);
+
+    $token = (new TokenProvider)->token();
+
+    expect($token)->toBe('the-token');
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/api/auth/token')
+        && $request['client_id'] === 'test-client-id'
+        && $request['client_secret'] === 'test-client-secret'
+        && $request['grant_type'] === 'client_credentials');
+});
+
+it('caches the token for the lifetime reported by Eupago', function () {
+    Http::fake(['*' => Http::response([
+        'access_token' => 'the-token',
+        'expires_in' => 3600,
+    ])]);
+
+    (new TokenProvider)->token();
+    $token = (new TokenProvider)->token();
+
+    expect($token)->toBe('the-token');
+    Http::assertSentCount(1);
+});
+
+it('does not cache a token that expires within the safety margin', function () {
+    Http::fake(['*' => Http::response([
+        'access_token' => 'short-lived',
+        'expires_in' => TokenProvider::EXPIRY_MARGIN,
+    ])]);
+
+    (new TokenProvider)->token();
+    (new TokenProvider)->token();
+
+    Http::assertSentCount(2);
+});
+
+it('throws when the token endpoint rejects the credentials', function () {
+    Http::fake(['*' => Http::response(['error' => 'invalid_client'], 400)]);
+
+    expect(fn () => (new TokenProvider)->token())->toThrow(RequestException::class);
+});
+
+it('throws when the token response contains no access token', function () {
+    Http::fake(['*' => Http::response(['token_type' => 'Bearer'])]);
+
+    expect(fn () => (new TokenProvider)->token())->toThrow(RuntimeException::class);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,8 @@ abstract class TestCase extends Orchestra
 
         $app['config']->set('eupago.api_key', 'test-api-key');
         $app['config']->set('eupago.channel', 'demo');
+        $app['config']->set('eupago.client_id', 'test-client-id');
+        $app['config']->set('eupago.client_secret', 'test-client-secret');
     }
 
     protected function defineDatabaseMigrations(): void


### PR DESCRIPTION
Closes #70

Adds the OAuth 2.0 foundation for Eupago's management API plus the first feature gated behind it: refunds. Ships as an additive minor (~v3.7.0) — the existing API-key transport for reference creation and status queries is untouched.

## What's included

**OAuth 2.0 foundation**
- New config keys `client_id` / `client_secret` (`EUPAGO_CLIENT_ID`, `EUPAGO_CLIENT_SECRET`), only needed for management calls
- `Auth\TokenProvider`: client credentials grant against `POST /api/auth/token`, caching the token for the `expires_in` lifetime minus a 60s safety margin, scoped by environment + client id
- `illuminate/cache` added to `require`, following the existing one-package-per-facade convention

**Refunds**
- `EuPago::refund($transactionId, $amount, ?$reason, ?$iban, ?$bic)` against `POST /api/management/v1.02/refund/{trid}`, keyed by the callback's `transacao`
- Partial and total refunds; optional IBAN/BIC for methods without a direct refund path
- Success maps to normalized keys (`success`, `status`, `refund_id`); rejections (HTTP 4xx with `transactionStatus: Rejected`) land in the existing error bag keyed by the rejection code, while transport/server errors throw — mirroring `create()`/`status()`

**Docs & tests**
- README: OAuth configuration section + Refunds section
- 12 new Pest feature tests (token grant, caching, expiry margin, credential rejection, refund success/rejection/server error, bearer transport, optional params, token reuse)

## Notes
- No migrations, no route changes — nothing for UPGRADE.md
- A live sandbox smoke test is pending OAuth client credentials for the sandbox account