### PR TITLE
docs(refunds): clarify conditional IBAN/BIC requirement

### DIFF
--- a/docs/refunds.md
+++ b/docs/refunds.md
@@ -24,8 +24,13 @@ try {
 }
 ```
 
-`refund()` also accepts an optional reason and, for payment methods without a direct
-refund path, the destination bank account:
+`refund()` also accepts an optional reason and the destination bank account. Payment
+methods with a direct refund path, such as MB WAY, return the money to its source and
+need nothing more. Methods without one, such as Multibanco, are refunded by bank
+transfer instead, so Eupago rejects the refund with `IBAN_MISSING` unless a
+destination IBAN is given. The matching BIC must always be sent together with the
+IBAN — Eupago does not derive it, and a refund with an IBAN but no BIC is rejected
+with `BIC_INVALID`:
 
 ```php
 $eupago->refund($transactionId, 10.50, reason: 'duplicate order', iban: 'PT50...', bic: 'BPOTPTPL');


### PR DESCRIPTION
Closes #76.

Live testing on the sandbox (2026-07-17) confirmed that the refund `iban` and `bic` fields, while marked optional in Eupago's API docs, are conditionally required: methods without a direct refund path (e.g. Multibanco) reject with `IBAN_MISSING` unless an IBAN is given, and an IBAN without its matching BIC is rejected with `BIC_INVALID` — Eupago does not derive the BIC. Direct-path methods such as MB WAY need neither.

This updates `docs/refunds.md` to spell that out, including the rejection codes users will see.