### PR TITLE
docs(frontmatter): group pages for the codetech.pt sidebar

### DIFF
--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -1,6 +1,7 @@
 ---
 title: Callbacks
 weight: 9
+group: Handling payments
 ---
 
 Eupago notifies your application of confirmed payments through a webhook — configure the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,7 @@
 ---
 title: Configuration
 weight: 4
+group: Getting started
 ---
 
 The package is configured through environment variables (see `config/eupago.php`):

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,7 @@
 ---
 title: Installation
 weight: 3
+group: Getting started
 ---
 
 Add the package to your Laravel application using Composer:

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 weight: 1
+group: Getting started
 ---
 
 [Eupago](https://www.eupago.pt) is a Portuguese payment gateway that lets businesses accept

--- a/docs/mbway.md
+++ b/docs/mbway.md
@@ -1,6 +1,7 @@
 ---
 title: MB WAY
 weight: 6
+group: Payment methods
 ---
 
 Create an MB WAY payment request — the customer confirms it on their phone through the

--- a/docs/multibanco.md
+++ b/docs/multibanco.md
@@ -1,6 +1,7 @@
 ---
 title: Multibanco (MB)
 weight: 5
+group: Payment methods
 ---
 
 Create an MB reference:

--- a/docs/paysafecard.md
+++ b/docs/paysafecard.md
@@ -1,6 +1,7 @@
 ---
 title: PaysafeCard
 weight: 8
+group: Payment methods
 ---
 
 Unlike the reference-based methods, PaysafeCard is a **redirect flow**: Eupago

--- a/docs/payshop.md
+++ b/docs/payshop.md
@@ -1,6 +1,7 @@
 ---
 title: PayShop
 weight: 7
+group: Payment methods
 ---
 
 Create a PayShop reference:

--- a/docs/reference-status.md
+++ b/docs/reference-status.md
@@ -1,6 +1,7 @@
 ---
 title: Querying reference status
 weight: 10
+group: Handling payments
 ---
 
 Besides the [callback](callbacks.md), you can query a reference's current status on

--- a/docs/refunds.md
+++ b/docs/refunds.md
@@ -1,6 +1,7 @@
 ---
 title: Refunds
 weight: 11
+group: Handling payments
 ---
 
 Paid transactions can be refunded, partially or in full, through Eupago's management

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,7 @@
 ---
 title: Requirements
 weight: 2
+group: Getting started
 ---
 
 | Package version                                                          | Laravel | PHP     | Status         |


### PR DESCRIPTION
Closes #78

Adds a `group` key to the frontmatter of every page in `docs/` so the codetech.pt sidebar can render section headings once CodeTechAgency/codetech-website#120 ships. Pages without a group keep rendering in the flat list, so this is safe to merge independently of the site work.

Grouping follows the existing weight order, so each group's pages are contiguous:

- **Getting started** — introduction, requirements, installation, configuration
- **Payment methods** — multibanco, mbway, payshop, paysafecard
- **Handling payments** — callbacks, reference-status, refunds

No other changes: body content, titles, weights, filenames, and `index.md` stay as they are.