### PR TITLE
docs(readme): split quick start into single-purpose code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ behind a simple API.
 
 ```bash
 composer require codetech/laravel-eupago
+```
+
+Publish and run the migrations:
+
+```bash
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=migrations
 php artisan migrate
 ```


### PR DESCRIPTION
Closes #80.

The Quick start opened with one bash block lumping three unrelated commands together. It now follows the same style as our other packages (e.g. laravel-vendus): `composer require` stands alone, and the migration steps get their own block introduced by a short sentence — matching what `docs/installation.md` already does.

The rest of the docs were scanned for similar occurrences: `docs/installation.md` is the only other page with multi-command blocks, and its blocks are already single-purpose with prose intros, so no changes were needed there.