### PR TITLE
docs: give every setup instruction its own code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,15 @@ behind a simple API.
 composer require codetech/laravel-eupago
 ```
 
-Publish and run the migrations:
+Publish the migrations:
 
 ```bash
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=migrations
+```
+
+Run them:
+
+```bash
 php artisan migrate
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Publish the migrations:
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=migrations
 ```
 
-Run them:
+Run the migrations:
 
 ```bash
 php artisan migrate

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ Publish the migrations:
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=migrations
 ```
 
-Run them:
+Run the migrations:
 
 ```bash
 php artisan migrate

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ Optionally, publish the configuration file:
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=config
 ```
 
-And the translations:
+You can also publish the translations:
 
 ```bash
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=translations

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,16 +12,26 @@ composer require codetech/laravel-eupago
 
 The service provider is registered automatically via package discovery.
 
-Publish and run the migrations:
+Publish the migrations:
 
 ```bash
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=migrations
+```
+
+Run them:
+
+```bash
 php artisan migrate
 ```
 
-Optionally, publish the configuration file and the translations:
+Optionally, publish the configuration file:
 
 ```bash
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=config
+```
+
+And the translations:
+
+```bash
 php artisan vendor:publish --provider="CodeTech\EuPago\Providers\EuPagoServiceProvider" --tag=translations
 ```


### PR DESCRIPTION
Closes #84.

Follow-up to #82, which applied the style rule only half-way. One instruction now means one code block with its own introducing sentence, exactly as in the laravel-api-logs Quick start:

- README Quick start: `vendor:publish` and `migrate` are now separate blocks.
- `docs/installation.md`: the same publish/migrate split, and the optional config and translations publishes each get their own block too.